### PR TITLE
Trello-CpRLlSMf: added maven built test action for pull request

### DIFF
--- a/.github/workflows/on-pull-request--build.yml
+++ b/.github/workflows/on-pull-request--build.yml
@@ -1,0 +1,9 @@
+name: Workflow executed when doing a pull request (open, reopen or update)
+
+on:
+  pull_request:
+    types: [opened, reopened, synchronize]
+
+jobs:
+  build-test-artifact:
+    uses: AngoraSix/infra/.github/workflows/action-build-test-maven.yml@main


### PR DESCRIPTION
Added maven build-test github actions that runs when a pull request is opened, reopened or updated.